### PR TITLE
download urls should allow themselves to be namespaced

### DIFF
--- a/downloads/models.py
+++ b/downloads/models.py
@@ -15,11 +15,11 @@ from downloads.managers import VisibleManager
 
 
 # root of all downloadable files
-DOWNLOAD_ROOT = 'downloads/'
+DOWNLOAD_ROOT = os.path.join(settings.MEDIA_ROOT, 'downloads')
 # path to media required for image modifications
-MOD_MEDIA_ROOT = os.path.join(DOWNLOAD_ROOT, 'mods/')
+MOD_MEDIA_ROOT = os.path.join(DOWNLOAD_ROOT, 'mods')
 # where temporary downloadable files are kept
-TEMP_ROOT = os.path.join(DOWNLOAD_ROOT, 'tmp/')
+TEMP_ROOT = os.path.join(DOWNLOAD_ROOT, 'tmp')
 
 
 class Download(ModelBase):

--- a/downloads/tests.py
+++ b/downloads/tests.py
@@ -8,7 +8,7 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.contrib.sites.models import Site
 
-from downloads.models import Download
+from downloads.models import Download, DOWNLOAD_ROOT
 
 
 class DownloadsTestCase(TestCase):
@@ -47,13 +47,11 @@ class DownloadsTestCase(TestCase):
     def test_header_is_being_set(self):
         '''Nginx header must be set for the server to serve the file'''
         dl = self.make_download()
-        slug = dl.slug
         response = self.client.get(
             reverse('download-request', kwargs={'slug': dl.slug})
         )
         self.assertEqual(response['X-Accel-Redirect'],
-            '%sdownloads/%s' % (settings.MEDIA_URL,
-            os.path.basename(dl.file.name)))
+            os.path.join(DOWNLOAD_ROOT, os.path.basename(dl.file.name)))
 
     def test_duplicate_filenames(self):
         """Two files with the same name are uploaded"""


### PR DESCRIPTION
Currently the Download `get_absolute_url` method does a reverse('download-request') which prevents us from using namespaces in our urls.
